### PR TITLE
Double literals and Comparisons in Ruby's CD

### DIFF
--- a/benchmarks/Java/src/cd/CollisionDetector.java
+++ b/benchmarks/Java/src/cd/CollisionDetector.java
@@ -76,10 +76,8 @@ public final class CollisionDetector {
     double y0 = init.y;
     double yv = fin.y - init.y;
 
-    double low_x;
-    double high_x;
-    low_x = (v_x - r - x0) / xv;
-    high_x = (v_x + v_s + r - x0) / xv;
+    double low_x = (v_x - r - x0) / xv;
+    double high_x = (v_x + v_s + r - x0) / xv;
 
     if (xv < 0.0) {
       double tmp = low_x;
@@ -87,10 +85,8 @@ public final class CollisionDetector {
       high_x = tmp;
     }
 
-    double low_y;
-    double high_y;
-    low_y  = (v_y - r - y0) / yv;
-    high_y = (v_y + v_s + r - y0) / yv;
+    double low_y  = (v_y - r - y0) / yv;
+    double high_y = (v_y + v_s + r - y0) / yv;
 
     if (yv < 0.0) {
       double tmp = low_y;

--- a/benchmarks/Java/src/deltablue/AbstractConstraint.java
+++ b/benchmarks/Java/src/deltablue/AbstractConstraint.java
@@ -71,21 +71,6 @@ abstract class AbstractConstraint {
   // Enforce this constraint. Assume that it is satisfied.
   public abstract void execute();
 
-  @FunctionalInterface
-  public interface BlockFunction {
-    class Return extends Exception {
-      private static final long serialVersionUID = 5527046579317358033L;
-      private final Object value;
-      Return(final Object value) {
-        this.value = value;
-      }
-      public Object getValue() {
-        return value;
-      }
-    }
-    void apply(Variable var) throws BlockFunction.Return;
-  }
-
   public abstract void inputsDo(ForEachInterface<Variable> fn);
   public abstract boolean inputsHasOne(TestInterface<Variable> fn);
 

--- a/benchmarks/Java/src/deltablue/UnaryConstraint.java
+++ b/benchmarks/Java/src/deltablue/UnaryConstraint.java
@@ -67,7 +67,7 @@ abstract class UnaryConstraint extends AbstractConstraint {
   @Override
   public boolean inputsHasOne(final som.TestInterface<Variable> fn) {
     return false;
-  };
+  }
 
   // Record the fact that I am unsatisfied.
   @Override

--- a/benchmarks/Ruby/cd.rb
+++ b/benchmarks/Ruby/cd.rb
@@ -643,8 +643,8 @@ class CollisionDetector
     x = GOOD_VOXEL_SIZE * x_div
     y = GOOD_VOXEL_SIZE * y_div
 
-    x -= GOOD_VOXEL_SIZE if position.x < 0
-    y -= GOOD_VOXEL_SIZE if position.y < 0
+    x -= GOOD_VOXEL_SIZE if position.x < 0.0
+    y -= GOOD_VOXEL_SIZE if position.y < 0.0
 
     Vector2D.new(x, y)
   end
@@ -794,10 +794,10 @@ class Simulator
     (0...@aircraft.size).step(2) do |i|
       frame.append(Aircraft.new(@aircraft.at(i),
                                 Vector3D.new(time,
-                                             Math.cos(time) * 2 + i * 3, 10.0)))
+                                             Math.cos(time) * 2.0 + i * 3.0, 10.0)))
       frame.append(Aircraft.new(@aircraft.at(i + 1),
                                 Vector3D.new(time,
-                                             Math.sin(time) * 2 + i * 3, 10.0)))
+                                             Math.sin(time) * 2.0 + i * 3.0, 10.0)))
     end
     frame
   end

--- a/benchmarks/Ruby/cd.rb
+++ b/benchmarks/Ruby/cd.rb
@@ -182,7 +182,7 @@ class RedBlackTree
           x.parent.parent.color = :red
           x = x.parent.parent
         else
-          if x == x.parent.right
+          if x.equal? x.parent.right
             # Case 2
             x = x.parent
             left_rotate(x)
@@ -203,7 +203,7 @@ class RedBlackTree
           x.parent.parent.color = :red
           x = x.parent.parent
         else
-          if x == x.parent.left
+          if x.equal? x.parent.left
             # Case 2
             x = x.parent
             right_rotate(x)
@@ -259,7 +259,7 @@ class RedBlackTree
       end
     end
 
-    if y != z
+    if !y.equal?(z)
       remove_fixup(x, x_parent) if y.color == :black
 
       y.parent = z.parent
@@ -363,7 +363,7 @@ class RedBlackTree
     unless x.parent
       @root = y
     else
-      if x == x.parent.left
+      if x.equal? x.parent.left
         x.parent.left = y
       else
         x.parent.right = y
@@ -403,8 +403,8 @@ class RedBlackTree
   end
 
   def remove_fixup(x, x_parent)
-    while x != @root && (!x || x.color == :black)
-      if x == x_parent.left
+    while !x.equal?(@root) && (!x || x.color == :black)
+      if x.equal? x_parent.left
         # Note: the text points out that w cannot be null.
         # The reason is not obvious from simply looking at the code;
         # it comes about from the properties of the red-black tree.


### PR DESCRIPTION
This turns literals into doubles where it seems to match other benchmarks.
Turn the `==` in the red-black tree to `.equal?` since this seems to match better the semantics in the other benchmarks.

@eregon could you sanity check this?