### PR TITLE
Fix CD benchmark for Smalltalk.

### DIFF
--- a/benchmarks/Smalltalk/CD/CollisionDetector.som
+++ b/benchmarks/Smalltalk/CD/CollisionDetector.som
@@ -94,9 +94,9 @@ CollisionDetector = (
     y0  := init y.
     yv  := fin y - init y.
 
-    xv = 0.0
+    xv = 0.0 "follow IEEE floating point semantics"
       ifTrue:  [
-        low_x  := Float negativeInfinity.
+        low_x  := Float infinity.
         high_x := Float infinity ]
       ifFalse: [
         low_x := (v_x - r - x0) / xv.
@@ -108,9 +108,9 @@ CollisionDetector = (
       low_x  := high_x.
       high_x := tmp ].
 
-    yv = 0.0
+    yv = 0.0 "follow IEEE floating point semantics"
       ifTrue: [
-        low_y  := Float negativeInfinity.
+        low_y  := Float infinity.
         high_y := Float infinity ]
       ifFalse: [
         low_y  := (v_y - r - y0) / yv.


### PR DESCRIPTION
The additional code in the Smalltalk version of `CollisionDetector>>isInVoxel:motion:` that forces IEEE floating point semantics used `Float negativeInfinity` instead of `Float infinity` for `low_x` and `low_y`. This has accidentally caused a max stack height of more than 500.000 (as opposed to 5), which in turn caused stack overflow errors in TruffleSqueak. With this fix in place, we can finally run the CD benchmark on TruffleSqueak.