### PR TITLE
Fix precedence bug in JsonObject>>#indexOf:

### DIFF
--- a/benchmarks/SOM/Json/JsonObject.som
+++ b/benchmarks/SOM/Json/JsonObject.som
@@ -64,7 +64,7 @@ JsonObject = JsonValue (
   indexOf: name = (
     | idx |
     idx := table at: name.    
-    idx <> 0 && name = (names at: idx) ifTrue: [ ^ idx ].
+    idx <> 0 && (name = (names at: idx)) ifTrue: [ ^ idx ].
     ^ self error: 'not implement'
   )
 


### PR DESCRIPTION
This change is made for consistency with the other languages.
This was already fixed in SOMns, and isn’t an issue in Smalltalk.
