### PR TITLE
[Ruby] Apply `# frozen_string_literal: true` to all benchmarks

### DIFF
--- a/benchmarks/Ruby/benchmark.rb
+++ b/benchmarks/Ruby/benchmark.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/benchmarks/Ruby/bounce.rb
+++ b/benchmarks/Ruby/bounce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>

--- a/benchmarks/Ruby/cd.rb
+++ b/benchmarks/Ruby/cd.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Ported from the adapted JavaScript and Java versions.
 #
 #     Copyright (c) 2001-2010, Purdue University. All rights reserved.

--- a/benchmarks/Ruby/deltablue.rb
+++ b/benchmarks/Ruby/deltablue.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The benchmark in its current state is a derivation from the SOM version,
 # which is derived from Mario Wolczko's Smalltalk version of DeltaBlue.
 #

--- a/benchmarks/Ruby/harness.rb
+++ b/benchmarks/Ruby/harness.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/benchmarks/Ruby/havlak.rb
+++ b/benchmarks/Ruby/havlak.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Adapted based on SOM benchmark.
 # Copyright 2011 Google Inc.
 #

--- a/benchmarks/Ruby/json.rb
+++ b/benchmarks/Ruby/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 # This benchmark is based on the minimal-json Java library maintained at:
 # https://github.com/ralfstx/minimal-json

--- a/benchmarks/Ruby/list.rb
+++ b/benchmarks/Ruby/list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>

--- a/benchmarks/Ruby/mandelbrot.rb
+++ b/benchmarks/Ruby/mandelbrot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Adapted based on SOM benchmark.
 #
 # Copyright (C) 2004-2013 Brent Fulgham

--- a/benchmarks/Ruby/nbody.rb
+++ b/benchmarks/Ruby/nbody.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The Computer Language Benchmarks Game
 # http://shootout.alioth.debian.org/
 #

--- a/benchmarks/Ruby/permute.rb
+++ b/benchmarks/Ruby/permute.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>

--- a/benchmarks/Ruby/queens.rb
+++ b/benchmarks/Ruby/queens.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>

--- a/benchmarks/Ruby/richards.rb
+++ b/benchmarks/Ruby/richards.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The benchmark in its current state is a derivation from the SOM version,
 # which is derived from Mario Wolczko's Smalltalk version of DeltaBlue.
 #

--- a/benchmarks/Ruby/run.rb
+++ b/benchmarks/Ruby/run.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/benchmarks/Ruby/sieve.rb
+++ b/benchmarks/Ruby/sieve.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>

--- a/benchmarks/Ruby/som.rb
+++ b/benchmarks/Ruby/som.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>

--- a/benchmarks/Ruby/storage.rb
+++ b/benchmarks/Ruby/storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>

--- a/benchmarks/Ruby/towers.rb
+++ b/benchmarks/Ruby/towers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This code is derived from the SOM benchmarks, see AUTHORS.md file.
 #
 # Copyright (c) 2015-2016 Stefan Marr <git@stefan-marr.de>


### PR DESCRIPTION
This PR changes the Ruby benchmarks to use frozen, i.e., immutable string literals.

It seems good engineering practice to have immutable strings, and it may enable further optimizations.

Arguably, this may even be more comparable to other languages, since strings are often immutable.

On the other hand, one may want a VM to figure out automatically that things are immutable to benefit from it. So, there’s a tradeoff here.

For the moment, it seems useful to go with the immutable version, which may become the default in Ruby at some point, too.

This addresses #72.

@eregon does this look alright to you?