### PR TITLE
Fix Vector.atPut not growing storage correctly

### DIFF
--- a/benchmarks/JavaScript/som.js
+++ b/benchmarks/JavaScript/som.js
@@ -49,7 +49,7 @@ Vector.prototype.at = function (idx) {
 };
 
 Vector.prototype.atPut = function (idx, val) {
-  if (this.idx >= this.storage.length) {
+  if (idx >= this.storage.length) {
     var newLength = this.storage.length;
     while (newLength <= idx) {
       newLength *= 2;


### PR DESCRIPTION
The type results in the `if` checking `undefined` >= length, which is always false.