### PR TITLE
Add Babel to Webpack config to be able to compile to ECMAScript 5

### DIFF
--- a/benchmarks/JavaScript/README.md
+++ b/benchmarks/JavaScript/README.md
@@ -1,0 +1,31 @@
+## Usage
+
+The JavaScript benchmarks can be run directly with a recent Node.js,
+for instance with:
+
+```
+node harness.js Queens 10 10
+```
+
+For other JavaScript runtime systems, the benchmarks may need to be 
+preprocessed. This repo contains the setup to use Bable and Webpack to compile
+the scripts into a more appropiate JavaScript version, or at least a single
+file.
+
+To create a single ECMAScript 5 compatible file, run:
+
+```
+npm install .
+npm run webpack
+```
+
+This will create a `dist/harness.es5.js` and a `dist/harness.es2022.js` file.
+These can be executed as before:
+
+```
+node dist/harness.es5.js Queens 10 10
+node dist/harness.es2022.js Queens 10 10
+```
+
+The `webpack.config.js` file shows these two configurations,
+and can be adapted to include other targets.

--- a/benchmarks/JavaScript/package.json
+++ b/benchmarks/JavaScript/package.json
@@ -10,12 +10,15 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@babel/core": "^7.19.6",
+    "@babel/preset-env": "^7.19.4",
+    "babel-loader": "^8.2.5",
     "eslint": "^8.23.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.2.5",
     "eslint-plugin-promise": "^6.0.1",
-    "webpack": "5.74.0",
+    "webpack": "^5.74.0",
     "webpack-cli": "4.10.0"
   }
 }

--- a/benchmarks/JavaScript/webpack.config.js
+++ b/benchmarks/JavaScript/webpack.config.js
@@ -9,5 +9,21 @@ module.exports = {
   output: {
     filename: 'harness.js',
     path: path.resolve(__dirname, 'dist'),
+    chunkFormat: 'commonjs'
   },
+  module: {
+    rules: [
+      {
+        test: /\.m?js$/,
+        exclude: /(node_modules|bower_components)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env']
+          }
+        }
+      }
+    ]
+  },
+  target: 'es5'
 };

--- a/benchmarks/JavaScript/webpack.config.js
+++ b/benchmarks/JavaScript/webpack.config.js
@@ -1,13 +1,13 @@
 const path = require('path');
 
-module.exports = {
+const es5 = {
   mode: 'production',
   optimization: {
     minimize: false
   },
   entry: './harness.js',
   output: {
-    filename: 'harness.js',
+    filename: 'harness.es5.js',
     path: path.resolve(__dirname, 'dist'),
     chunkFormat: 'commonjs'
   },
@@ -27,3 +27,19 @@ module.exports = {
   },
   target: 'es5'
 };
+
+const es2022 = {
+  mode: 'production',
+  optimization: {
+    minimize: false
+  },
+  entry: './harness.js',
+  output: {
+    filename: 'harness.es2022.js',
+    path: path.resolve(__dirname, 'dist'),
+    chunkFormat: 'commonjs'
+  },
+  target: 'es2022'
+};
+
+module.exports = [es5, es2022];


### PR DESCRIPTION
Just running `npm install . && npm run webpack` will generate a plain es5 compatible dist/harness.js file.

Without babel, we would get a single file version of AWFY, which may also be useful for some runtime systems.