### PR TITLE
Fixing various minor issues in benchmarks

### DIFF
--- a/benchmarks/Crystal/richards.cr
+++ b/benchmarks/Crystal/richards.cr
@@ -59,7 +59,7 @@ class RBObject
 end
 
 class RichardsScheduler < RBObject
-  
+
   @task_list    : TaskControlBlock?
   @current_task : TaskControlBlock?
 
@@ -83,7 +83,7 @@ class RichardsScheduler < RBObject
     create_task(identity, priority, work, state, data) { | work, word |
       data_record = word.as(DeviceTaskDataRecord)
       function_work = work
-      if function_work # NO_WORK == 
+      if function_work # NO_WORK ==
         data_record.pending = function_work
         if TRACING
           trace(function_work.datum)
@@ -91,7 +91,7 @@ class RichardsScheduler < RBObject
         hold_self
       else
         function_work = data_record.pending
-        if function_work ## NO_WORK == 
+        if function_work ## NO_WORK ==
           data_record.pending = NO_WORK
           queue_packet(function_work)
         else
@@ -132,7 +132,7 @@ class RichardsScheduler < RBObject
           end
         end
       else
-        # NO_WORK == 
+        # NO_WORK ==
         wait
       end
     }
@@ -161,7 +161,7 @@ class RichardsScheduler < RBObject
     Packet.new(link, identity, kind)
   end
 
-  def create_task(identity : Int32, priority : Int32, work : Packet?, 
+  def create_task(identity : Int32, priority : Int32, work : Packet?,
                   state : TaskState, data, &block : Packet?, RBObject -> TaskControlBlock?)
     t = TaskControlBlock.new(@task_list, identity, priority, work, state, data, &block)
     @task_list = t
@@ -184,7 +184,7 @@ class RichardsScheduler < RBObject
           work.data[i] = 65 + data.count - 1
         }
         queue_packet(work)
-      else # NO_WORK == 
+      else # NO_WORK ==
         wait
       end
     }
@@ -234,7 +234,7 @@ class RichardsScheduler < RBObject
     if NO_TASK == task_or_no_task
       return NO_TASK
     end
-    
+
     task = task_or_no_task.not_nil!
 
     @queue_count += 1
@@ -249,7 +249,7 @@ class RichardsScheduler < RBObject
     if NO_TASK == task_or_no_task
       return NO_TASK
     end
-    
+
     task = task_or_no_task.not_nil!
 
     task.task_holding = false
@@ -295,9 +295,9 @@ class RichardsScheduler < RBObject
 end
 
 class DeviceTaskDataRecord < RBObject
-  
+
   @pending : Packet?
-  
+
   property :pending
    def initialize
     @pending = NO_WORK
@@ -306,10 +306,10 @@ end
 
 class HandlerTaskDataRecord < RBObject
   property :work_in, :device_in
-  
+
   @work_in   : Packet?
   @device_in : Packet?
-  
+
   def initialize
     @work_in   = NO_WORK
     @device_in = NO_WORK
@@ -338,7 +338,7 @@ class Packet < RBObject
   property :link, :kind, :identity, :datum, :data
 
   @data : Array(Int32)
-  
+
   def initialize(link : Packet?, identity : Int32, kind : Int32)
     @link     = link
     @kind     = kind
@@ -393,24 +393,12 @@ class TaskState < RBObject
     self
   end
 
-  def is_running
-    !@packet_pending && !@task_waiting && !@task_holding
-  end
-
   def is_task_holding_or_waiting
     @task_holding || (!@packet_pending && @task_waiting)
   end
 
-  def is_waiting
-    !@packet_pending && @task_waiting && !@task_holding
-  end
-
   def is_waiting_with_packet
     @packet_pending && @task_waiting && !@task_holding
-  end
-
-  def self.packet_pending
-    self.new.packet_pending
   end
 
   def self.running

--- a/benchmarks/Java/src/List.java
+++ b/benchmarks/Java/src/List.java
@@ -50,7 +50,7 @@ public final class List extends Benchmark {
     return result.length();
   }
 
-  public Element makeList(final int length) {
+  private Element makeList(final int length) {
     if (length == 0) { return null; } else {
       Element e = new Element(length);
       e.setNext(makeList(length - 1));
@@ -58,7 +58,7 @@ public final class List extends Benchmark {
     }
   }
 
-  public boolean isShorterThan(final Element x, final Element y) {
+  private boolean isShorterThan(final Element x, final Element y) {
     Element xTail = x;
     Element yTail = y;
 
@@ -70,7 +70,7 @@ public final class List extends Benchmark {
     return false;
   }
 
-  public Element tail(final Element x, final Element y, final Element z) {
+  private Element tail(final Element x, final Element y, final Element z) {
     if (isShorterThan(y, x)) {
       return tail(tail(x.getNext(), y, z),
              tail(y.getNext(), z, x),

--- a/benchmarks/Java/src/Mandelbrot.java
+++ b/benchmarks/Java/src/Mandelbrot.java
@@ -88,7 +88,6 @@ final class Mandelbrot extends Benchmark {
        int x = 0;
 
        while (x < size) {
-         double zr   = 0.0;
          double zrzr = 0.0;
          double zi   = 0.0;
          double zizi = 0.0;
@@ -98,7 +97,7 @@ final class Mandelbrot extends Benchmark {
          boolean notDone = true;
          int escape = 0;
          while (notDone && z < 50) {
-           zr = zrzr - zizi + cr;
+           double zr = zrzr - zizi + cr;
            zi = 2.0 * zr * zi + ci;
 
            // preserve recalculation

--- a/benchmarks/Java/src/Queens.java
+++ b/benchmarks/Java/src/Queens.java
@@ -48,7 +48,7 @@ public class Queens extends Benchmark {
     return placeQueen(0);
   }
 
-  boolean placeQueen(final int c) {
+  private boolean placeQueen(final int c) {
     for (int r = 0; r < 8; r++) {
       if (getRowColumn(r, c)) {
         queenRows[r] = c;
@@ -67,11 +67,11 @@ public class Queens extends Benchmark {
     return false;
   }
 
-  boolean getRowColumn(final int r, final int c) {
+  private boolean getRowColumn(final int r, final int c) {
     return freeRows[r] && freeMaxs[c + r] && freeMins[c - r + 7];
   }
 
-  void setRowColumn(final int r, final int c, final boolean v) {
+  private void setRowColumn(final int r, final int c, final boolean v) {
     freeRows[r        ] = v;
     freeMaxs[c + r    ] = v;
     freeMins[c - r + 7] = v;

--- a/benchmarks/Java/src/nbody/NBodySystem.java
+++ b/benchmarks/Java/src/nbody/NBodySystem.java
@@ -67,10 +67,6 @@ public class NBodySystem {
   }
 
   public double energy() {
-    double dx;
-    double dy;
-    double dz;
-    double distance;
     double e = 0.0;
 
     for (int i = 0; i < bodies.length; ++i) {
@@ -82,11 +78,11 @@ public class NBodySystem {
 
       for (int j = i + 1; j < bodies.length; ++j) {
         Body jBody = bodies[j];
-        dx = iBody.getX() - jBody.getX();
-        dy = iBody.getY() - jBody.getY();
-        dz = iBody.getZ() - jBody.getZ();
+        double dx = iBody.getX() - jBody.getX();
+        double dy = iBody.getY() - jBody.getY();
+        double dz = iBody.getZ() - jBody.getZ();
 
-        distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        double distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
         e -= (iBody.getMass() * jBody.getMass()) / distance;
       }
     }

--- a/benchmarks/Java/src/richards/TaskState.java
+++ b/benchmarks/Java/src/richards/TaskState.java
@@ -1,7 +1,7 @@
 /*
  * This benchmark is derived from Mario Wolczko's Java and Smalltalk version of
  * Richards.
- * 
+ *
  * It is modified based on the SOM version and to use Java 8 features.
  * License details:
  *   http://web.archive.org/web/20050825101121/http://www.sunlabs.com/people/mario/java_benchmarking/index.html
@@ -42,26 +42,12 @@ class TaskState extends RBObject {
     taskWaiting = packetPending = true;
   }
 
-  public boolean isRunning() {
-    return !packetPending && !taskWaiting && !taskHolding;
-  }
-
   public boolean isTaskHoldingOrWaiting() {
     return taskHolding || (!packetPending && taskWaiting);
   }
 
-  public boolean isWaiting() {
-    return !packetPending && taskWaiting && !taskHolding;
-  }
-
   public boolean isWaitingWithPacket() {
     return packetPending && taskWaiting && !taskHolding;
-  }
-
-  public static TaskState createPacketPending() {
-    TaskState t = new TaskState();
-    t.packetPending();
-    return t;
   }
 
   public static TaskState createRunning() {

--- a/benchmarks/JavaScript/mandelbrot.js
+++ b/benchmarks/JavaScript/mandelbrot.js
@@ -67,7 +67,6 @@ class Mandelbrot extends Benchmark {
       let x = 0;
 
       while (x < size) {
-        let zr = 0.0;
         let zrzr = 0.0;
         let zi = 0.0;
         let zizi = 0.0;
@@ -77,7 +76,7 @@ class Mandelbrot extends Benchmark {
         let notDone = true;
         let escape = 0;
         while (notDone && z < 50) {
-          zr = zrzr - zizi + cr;
+          const zr = zrzr - zizi + cr;
           zi = 2.0 * zr * zi + ci;
 
           // preserve recalculation

--- a/benchmarks/JavaScript/nbody.js
+++ b/benchmarks/JavaScript/nbody.js
@@ -143,10 +143,6 @@ class NBodySystem {
   }
 
   energy() {
-    let dx = 0.0;
-    let dy = 0.0;
-    let dz = 0.0;
-    let distance = 0.0;
     let e = 0.0;
 
     for (let i = 0; i < this.bodies.length; i += 1) {
@@ -157,11 +153,11 @@ class NBodySystem {
 
       for (let j = i + 1; j < this.bodies.length; j += 1) {
         const jBody = this.bodies[j];
-        dx = iBody.x - jBody.x;
-        dy = iBody.y - jBody.y;
-        dz = iBody.z - jBody.z;
+        const dx = iBody.x - jBody.x;
+        const dy = iBody.y - jBody.y;
+        const dz = iBody.z - jBody.z;
 
-        distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
         e -= (iBody.mass * jBody.mass) / distance;
       }
     }

--- a/benchmarks/JavaScript/richards.js
+++ b/benchmarks/JavaScript/richards.js
@@ -86,26 +86,12 @@ class TaskState extends RBObject {
     this.packetPending_ = true;
   }
 
-  isRunning() {
-    return !this.packetPending_ && !this.taskWaiting_ && !this.taskHolding_;
-  }
-
   isTaskHoldingOrWaiting() {
     return this.taskHolding_ || (!this.packetPending_ && this.taskWaiting_);
   }
 
-  isWaiting() {
-    return !this.packetPending_ && this.taskWaiting_ && !this.taskHolding_;
-  }
-
   isWaitingWithPacket() {
     return this.packetPending_ && this.taskWaiting_ && !this.taskHolding_;
-  }
-
-  static createPacketPending() {
-    const t = new TaskState();
-    t.packetPending();
-    return t;
   }
 
   static createRunning() {

--- a/benchmarks/Lua/mandelbrot-fn-53.lua
+++ b/benchmarks/Lua/mandelbrot-fn-53.lua
@@ -23,7 +23,7 @@ local function mandelbrot (size)
         local x  = 0
 
         while x < size do
-            local zrzr, zr = 0.0
+            local zrzr = 0.0
             local zizi, zi = 0.0, 0.0
             local cr   = (2.0 * x / size) - 1.5
 
@@ -31,7 +31,7 @@ local function mandelbrot (size)
             local not_done = true
             local escape = 0
             while not_done and z < 50 do
-                zr = zrzr - zizi + cr
+                local zr = zrzr - zizi + cr
                 zi = 2.0 * zr * zi + ci
 
                 -- preserve recalculation

--- a/benchmarks/Lua/mandelbrot-fn.lua
+++ b/benchmarks/Lua/mandelbrot-fn.lua
@@ -26,7 +26,7 @@ local function mandelbrot (size)
         local x  = 0
 
         while x < size do
-            local zrzr, zr = 0.0
+            local zrzr = 0.0
             local zizi, zi = 0.0, 0.0
             local cr   = (2.0 * x / size) - 1.5
 
@@ -34,7 +34,7 @@ local function mandelbrot (size)
             local not_done = true
             local escape = 0
             while not_done and z < 50 do
-                zr = zrzr - zizi + cr
+                local zr = zrzr - zizi + cr
                 zi = 2.0 * zr * zi + ci
 
                 -- preserve recalculation

--- a/benchmarks/Lua/richards.lua
+++ b/benchmarks/Lua/richards.lua
@@ -195,24 +195,12 @@ function TaskState:waiting_with_packet ()
     return self
 end
 
-function TaskState:is_running ()
-    return not self.packt_pending and not self.task_waiting and not self.task_holding
-end
-
 function TaskState:is_task_holding_or_waiting ()
     return self.task_holding or (not self.packt_pending and self.task_waiting)
 end
 
-function TaskState:is_waiting ()
-    return not self.packt_pending and self.task_waiting and not self.task_holding
-end
-
 function TaskState:is_waiting_with_packet ()
     return self.packt_pending and self.task_waiting and not self.task_holding
-end
-
-function TaskState.create_packet_pending ()
-    return TaskState.new():packet_pending()
 end
 
 function TaskState.create_running ()

--- a/benchmarks/Python/mandelbrot.py
+++ b/benchmarks/Python/mandelbrot.py
@@ -79,7 +79,6 @@ class Mandelbrot(Benchmark):
             x = 0
 
             while x < size:
-                zr = 0.0
                 zrzr = 0.0
                 zi = 0.0
                 zizi = 0.0

--- a/benchmarks/Python/richards.py
+++ b/benchmarks/Python/richards.py
@@ -330,27 +330,11 @@ class _TaskState(_RBObject):
         self._task_waiting = self._packet_pending = True
         return self
 
-    def is_running(self):
-        return (
-            not self._packet_pending
-            and not self._task_waiting
-            and not self._task_holding
-        )
-
     def is_task_holding_or_waiting(self):
         return self._task_holding or (not self._packet_pending and self._task_waiting)
 
-    def is_waiting(self):
-        return (
-            not self._packet_pending and self._task_waiting and not self._task_holding
-        )
-
     def is_waiting_with_packet(self):
         return self._packet_pending and self._task_waiting and not self._task_holding
-
-    @classmethod
-    def with_packet_pending(cls):
-        return cls().packet_pending()
 
     @classmethod
     def with_running(cls):

--- a/benchmarks/Ruby/mandelbrot.rb
+++ b/benchmarks/Ruby/mandelbrot.rb
@@ -70,7 +70,7 @@ class Mandelbrot < Benchmark
       x  = 0
 
       while x < size
-        zrzr = zr = 0.0
+        zrzr = 0.0
         zizi = zi = 0.0
         cr   = (2.0 * x / size) - 1.5
 

--- a/benchmarks/Ruby/richards.rb
+++ b/benchmarks/Ruby/richards.rb
@@ -360,24 +360,12 @@ class TaskState < RBObject
     self
   end
 
-  def is_running
-    !@packet_pending && !@task_waiting && !@task_holding
-  end
-
   def is_task_holding_or_waiting
     @task_holding || (!@packet_pending && @task_waiting)
   end
 
-  def is_waiting
-    !@packet_pending && @task_waiting && !@task_holding
-  end
-
   def is_waiting_with_packet
     @packet_pending && @task_waiting && !@task_holding
-  end
-
-  def self.packet_pending
-    new.packet_pending
   end
 
   def self.running

--- a/benchmarks/SOM/Mandelbrot.som
+++ b/benchmarks/SOM/Mandelbrot.som
@@ -7,24 +7,24 @@
   The original copyright statement reads as follows:
 
 # Copyright © 2004-2013 Brent Fulgham
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #   * Redistributions of source code must retain the above copyright notice,
 #     this list of conditions and the following disclaimer.
-# 
+#
 #   * Redistributions in binary form must reproduce the above copyright notice,
 #     this list of conditions and the following disclaimer in the documentation
 #     and/or other materials provided with the distribution.
-# 
+#
 #   * Neither the name of 'The Computer Language Benchmarks Game' nor the name
 #     of 'The Computer Language Shootout Benchmarks' nor the names of its
 #     contributors may be used to endorse or promote products derived from this
 #     software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,21 +35,21 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 # The Computer Language Benchmarks Game
 # http://benchmarksgame.alioth.debian.org
-# 
+#
 #  contributed by Karl von Laudermann
 #  modified by Jeremy Echols
 #  modified by Detlef Reichl
 #  modified by Joseph LaFata
 #  modified by Peter Zotov
-# 
+#
 # http://benchmarksgame.alioth.debian.org/u64q/program.php?test=mandelbrot&lang=yarv&id=3
 "
 Mandelbrot = Benchmark (
 
-  innerBenchmarkLoop: innerIterations = ( 
+  innerBenchmarkLoop: innerIterations = (
     ^ self verify: (self mandelbrot: innerIterations) inner: innerIterations
   )
 
@@ -70,29 +70,30 @@ Mandelbrot = Benchmark (
       bitNum  := 0.
 
       y := 0.
-      
+
       [y < size] whileTrue: [
           | ci x |
           ci := (2.0 * y // size) - 1.0.
           x  := 0.
-          
+
           [x < size] whileTrue: [
-              | zr zrzr zi zizi cr escape z notDone |
-              zrzr := zr := 0.0.
+              | zrzr zi zizi cr escape z notDone |
+              zrzr := 0.0.
               zizi := zi := 0.0.
               cr   := (2.0 * x // size) - 1.5.
-              
+
               z := 0.
               notDone := true.
               escape := 0.
               [notDone and: [z < 50]] whileTrue: [
+                  | zr |
                   zr := zrzr - zizi + cr.
                   zi := 2.0 * zr * zi + ci.
-          
+
                   "preserve recalculation"
                   zrzr := zr * zr.
                   zizi := zi * zi.
-          
+
                   (zrzr + zizi > 4.0) ifTrue: [
                       notDone := false.
                       escape  := 1.
@@ -106,7 +107,7 @@ Mandelbrot = Benchmark (
               " Code is very similar for these cases, but using separate blocks
                 ensures we skip the shifting when it's unnecessary,
                 which is most cases. "
-              bitNum = 8 
+              bitNum = 8
                   ifTrue: [
                     sum := sum bitXor: byteAcc.
                     byteAcc := 0.
@@ -121,7 +122,7 @@ Mandelbrot = Benchmark (
           ].
           y := y + 1.
       ].
-      
+
       ^ sum
   )
 )

--- a/benchmarks/SOM/NBody/NBodySystem.som
+++ b/benchmarks/SOM/NBody/NBodySystem.som
@@ -3,13 +3,13 @@
 
   contributed by Mark C. Lewis
   modified slightly by Chad Whipkey
-  
+
   Based on nbody.java ported to SOM by Stefan Marr.
   See LICENSE.md file.
 "
 NBodySystem = (
   | bodies |
-  
+
   initialize = (
     bodies := self createBodies
   )
@@ -23,7 +23,7 @@ NBodySystem = (
     bodies at: 3 put: Body saturn.
     bodies at: 4 put: Body uranus.
     bodies at: 5 put: Body neptune.
-    
+
     "bodies do: [:b | b print. '' println ]."
 
     px := 0.0.  py := 0.0.  pz := 0.0.
@@ -33,9 +33,9 @@ NBodySystem = (
         py := py + (b vy * b mass).
         pz := pz + (b vz * b mass).
     ].
-    
+
     (bodies at: 1) offsetMomentumX: px y: py z: pz.
-    
+
     "bodies do: [:b | b print. '' println ]."
     ^ bodies
   )
@@ -72,24 +72,24 @@ NBodySystem = (
        body z: body z + (dt * body vz).
     ].
   )
-  
+
   energy = (
-    | dx dy dz distance e |
+    | e |
     e := 0.0.
 
     1 to: bodies length do: [:i |
       | iBody |
       iBody := bodies at: i.
-  
+
       e := e + (0.5 * iBody mass *
            ((iBody vx * iBody vx) +
             (iBody vy * iBody vy) +
             (iBody vz * iBody vz))).
-  
+
       i + 1 to: bodies length do: [:j |
-          | jBody |
+          | jBody dx dy dz distance |
           jBody := bodies at: j.
-      
+
           dx := iBody x - jBody x.
           dy := iBody y - jBody y.
           dz := iBody z - jBody z.
@@ -100,9 +100,9 @@ NBodySystem = (
     ].
     ^ e
   )
-  
+
   ----
-  
+
   new = (
       ^ super new initialize
   )

--- a/benchmarks/SOM/Richards/TaskState.som
+++ b/benchmarks/SOM/Richards/TaskState.som
@@ -38,18 +38,11 @@ TaskState = RBObject (
       taskWaiting := packetPending := true
   )
 
-  isRunning = ( ^ packetPending not and: [taskWaiting not and: [taskHolding not]] )
-
   isTaskHoldingOrWaiting = ( ^ taskHolding or: [packetPending not and: [taskWaiting]] )
-
-  isWaiting = ( ^ packetPending not and: [taskWaiting and: [taskHolding not]] )
 
   isWaitingWithPacket = ( ^ packetPending and: [taskWaiting and: [taskHolding not]] )
 
-
   ----
-  packetPending = ( ^ super new packetPending )
-
   running = ( ^ super new running )
 
   waiting = ( ^ super new waiting )

--- a/benchmarks/SOMns/List.ns
+++ b/benchmarks/SOMns/List.ns
@@ -35,7 +35,7 @@ class ListSuite usingPlatform: platform andHarness: harness = (
       ^ 10 = result
     )
 
-    makeList: length = (
+    private makeList: length = (
       (length = 0)
         ifTrue: [ ^ nil ]
         ifFalse: [
@@ -45,7 +45,7 @@ class ListSuite usingPlatform: platform andHarness: harness = (
           ^ e ]
     )
 
-    isShorter: x than: y = (
+    private isShorter: x than: y = (
       | xTail yTail |
 
       xTail:: x. yTail:: y.
@@ -58,7 +58,7 @@ class ListSuite usingPlatform: platform andHarness: harness = (
       ^ false
     )
 
-    tailWithX: x withY: y withZ: z = (
+    private tailWithX: x withY: y withZ: z = (
       (self isShorter: y than: x)
         ifTrue: [
           ^ (self

--- a/benchmarks/SOMns/Mandelbrot.ns
+++ b/benchmarks/SOMns/Mandelbrot.ns
@@ -77,8 +77,8 @@ class MandelbrotSuite usingPlatform: platform andHarness: harness = (
           x::  0.
 
           [x < size] whileTrue: [
-              | zr zrzr zi zizi cr escape z notDone |
-              zrzr:: zr:: 0.0.
+              | zrzr zi zizi cr escape z notDone |
+              zrzr:: 0.0.
               zizi:: zi:: 0.0.
               cr::   (2.0 * x // size) - 1.5.
 
@@ -86,6 +86,7 @@ class MandelbrotSuite usingPlatform: platform andHarness: harness = (
               notDone:: true.
               escape:: 0.
               [notDone and: [z < 50]] whileTrue: [
+                  | zr |
                   zr:: zrzr - zizi + cr.
                   zi:: 2.0 * zr * zi + ci.
 

--- a/benchmarks/SOMns/NBody.ns
+++ b/benchmarks/SOMns/NBody.ns
@@ -99,7 +99,7 @@ class NBodySuite usingPlatform: platform andHarness: harness = (
     )
 
     public energy = (
-      | dx dy dz distance e |
+      | e |
       e:: 0.0.
 
       1 to: bodies size do: [:i |
@@ -112,7 +112,7 @@ class NBodySuite usingPlatform: platform andHarness: harness = (
               (iBody vz * iBody vz))).
 
         i + 1 to: bodies size do: [:j |
-          | jBody |
+          | jBody dx dy dz distance |
           jBody:: bodies at: j.
 
           dx:: iBody x - jBody x.

--- a/benchmarks/SOMns/Queens.ns
+++ b/benchmarks/SOMns/Queens.ns
@@ -63,7 +63,7 @@ class QueensSuite usingPlatform: platform andHarness: harness = (
       ^(freeRows at: r) && (freeMaxs at: c + r) && (freeMins at: c - r + 8)
     )
 
-    row: r column: c put: v = (
+    private row: r column: c put: v = (
       freeRows at: r         put: v.
       freeMaxs at: c + r     put: v.
       freeMins at: c - r + 8 put: v.

--- a/benchmarks/SOMns/Richards.ns
+++ b/benchmarks/SOMns/Richards.ns
@@ -384,12 +384,9 @@ class RichardsBenchmark usingPlatform: platform andHarness: harness = (
       taskWaiting_:: packetPending_:: true
     )
 
-    public isRunning = ( ^ packetPending_ not and: [taskWaiting_ not and: [taskHolding_ not]])
     public isTaskHoldingOrWaiting = ( ^ taskHolding_ or: [packetPending_ not and: [taskWaiting_]])
-    public isWaiting = (^ packetPending_ not and: [taskWaiting_ and: [taskHolding_ not]])
     public isWaitingWithPacket = ( ^ packetPending_ and: [taskWaiting_ and: [taskHolding_ not]])
   ) : (
-    public packetPending = ( ^ self new packetPending )
     public running       = ( ^ self new running )
     public waiting       = ( ^ self new waiting )
     public waitingWithPacket = ( ^ self new waitingWithPacket )

--- a/benchmarks/Smalltalk/Mandelbrot.som
+++ b/benchmarks/Smalltalk/Mandelbrot.som
@@ -7,24 +7,24 @@
   The original copyright statement reads as follows:
 
 # Copyright © 2004-2013 Brent Fulgham
-# 
+#
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 #   * Redistributions of source code must retain the above copyright notice,
 #     this list of conditions and the following disclaimer.
-# 
+#
 #   * Redistributions in binary form must reproduce the above copyright notice,
 #     this list of conditions and the following disclaimer in the documentation
 #     and/or other materials provided with the distribution.
-# 
+#
 #   * Neither the name of 'The Computer Language Benchmarks Game' nor the name
 #     of 'The Computer Language Shootout Benchmarks' nor the names of its
 #     contributors may be used to endorse or promote products derived from this
 #     software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -35,21 +35,21 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-# 
+#
 # The Computer Language Benchmarks Game
 # http://benchmarksgame.alioth.debian.org
-# 
+#
 #  contributed by Karl von Laudermann
 #  modified by Jeremy Echols
 #  modified by Detlef Reichl
 #  modified by Joseph LaFata
 #  modified by Peter Zotov
-# 
+#
 # http://benchmarksgame.alioth.debian.org/u64q/program.php?test=mandelbrot&lang=yarv&id=3
 "
 Mandelbrot = Benchmark (
 
-  innerBenchmarkLoop: innerIterations = ( 
+  innerBenchmarkLoop: innerIterations = (
     ^ self verify: (self mandelbrot: innerIterations) inner: innerIterations
   )
 
@@ -70,29 +70,30 @@ Mandelbrot = Benchmark (
       bitNum  := 0.
 
       y := 0.
-      
+
       [y < size] whileTrue: [
           | ci x |
           ci := (2.0 * y / size) - 1.0.
           x  := 0.
-          
+
           [x < size] whileTrue: [
-              | zr zrzr zi zizi cr escape z notDone |
-              zrzr := zr := 0.0.
+              | zrzr zi zizi cr escape z notDone |
+              zrzr := 0.0.
               zizi := zi := 0.0.
               cr   := (2.0 * x / size) - 1.5.
-              
+
               z := 0.
               notDone := true.
               escape := 0.
               [notDone and: [z < 50]] whileTrue: [
+                  | zr |
                   zr := zrzr - zizi + cr.
                   zi := 2.0 * zr * zi + ci.
-          
+
                   "preserve recalculation"
                   zrzr := zr * zr.
                   zizi := zi * zi.
-          
+
                   (zrzr + zizi > 4.0) ifTrue: [
                       notDone := false.
                       escape  := 1.
@@ -106,7 +107,7 @@ Mandelbrot = Benchmark (
               " Code is very similar for these cases, but using separate blocks
                 ensures we skip the shifting when it's unnecessary,
                 which is most cases. "
-              bitNum = 8 
+              bitNum = 8
                   ifTrue: [
                     sum := sum bitXor: byteAcc.
                     byteAcc := 0.
@@ -121,7 +122,7 @@ Mandelbrot = Benchmark (
           ].
           y := y + 1.
       ].
-      
+
       ^ sum
   )
 )

--- a/benchmarks/Smalltalk/NBody/NBodySystem.som
+++ b/benchmarks/Smalltalk/NBody/NBodySystem.som
@@ -3,13 +3,13 @@
 
   contributed by Mark C. Lewis
   modified slightly by Chad Whipkey
-  
+
   Based on nbody.java ported to SOM by Stefan Marr.
   See LICENSE.md file.
 "
 NBodySystem = (
   | bodies |
-  
+
   initialize = (
     bodies := self createBodies
   )
@@ -23,7 +23,7 @@ NBodySystem = (
     bodies at: 3 put: Body saturn.
     bodies at: 4 put: Body uranus.
     bodies at: 5 put: Body neptune.
-    
+
     "bodies do: [:b | b print. '' println ]."
 
     px := 0.0.  py := 0.0.  pz := 0.0.
@@ -33,9 +33,9 @@ NBodySystem = (
         py := py + (b vy * b mass).
         pz := pz + (b vz * b mass).
     ].
-    
+
     (bodies at: 1) offsetMomentumX: px y: py z: pz.
-    
+
     "bodies do: [:b | b print. '' println ]."
     ^ bodies
   )
@@ -72,24 +72,24 @@ NBodySystem = (
        body z: body z + (dt * body vz).
     ].
   )
-  
+
   energy = (
-    | dx dy dz distance e |
+    | e |
     e := 0.0.
 
     1 to: bodies size do: [:i |
       | iBody |
       iBody := bodies at: i.
-  
+
       e := e + (0.5 * iBody mass *
            ((iBody vx * iBody vx) +
             (iBody vy * iBody vy) +
             (iBody vz * iBody vz))).
-  
+
       i + 1 to: bodies size do: [:j |
-          | jBody |
+          | jBody dx dy dz distance |
           jBody := bodies at: j.
-      
+
           dx := iBody x - jBody x.
           dy := iBody y - jBody y.
           dz := iBody z - jBody z.
@@ -100,9 +100,9 @@ NBodySystem = (
     ].
     ^ e
   )
-  
+
   ----
-  
+
   new = (
       ^ super new initialize
   )

--- a/benchmarks/Smalltalk/Richards/TaskState.som
+++ b/benchmarks/Smalltalk/Richards/TaskState.som
@@ -38,18 +38,12 @@ TaskState = RBObject (
       taskWaiting := packetPending := true
   )
 
-  isRunning = ( ^ packetPending not and: [taskWaiting not and: [taskHolding not]] )
-
   isTaskHoldingOrWaiting = ( ^ taskHolding or: [packetPending not and: [taskWaiting]] )
-
-  isWaiting = ( ^ packetPending not and: [taskWaiting and: [taskHolding not]] )
 
   isWaitingWithPacket = ( ^ packetPending and: [taskWaiting and: [taskHolding not]] )
 
 
   ----
-  packetPending = ( ^ super new packetPending )
-
   running = ( ^ super new running )
 
   waiting = ( ^ super new waiting )


### PR DESCRIPTION
These are various little things, like making methods private, removing dead code, and moving variables in more local scopes.

These were discovered when porting to C#.