### PR TITLE
Disable Pharo in CI and fix Rubocop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           - name: SOMns
             id:   somns
 
-          - name: Pharo
-            id:   pharo
+          # - name: Pharo
+          #   id:   pharo
 
           - name: Squeak 64-bit
             id:   squeak64

--- a/benchmarks/Ruby/.rubocop.yml
+++ b/benchmarks/Ruby/.rubocop.yml
@@ -21,11 +21,6 @@ Style/IfInsideElse:
 Style/NumericPredicate:
   Enabled: false
 
-Style/IfUnlessModifier:
-  Exclude:
-    - 'harness.rb'
-    - 'havlak.rb'
-  
 Style/HashEachMethods:
   Enabled: false
 
@@ -176,5 +171,9 @@ Style/OrAssignment:
   Enabled: false
 
 Style/RedundantCondition:
+  Exclude:
+    - 'cd.rb'
+
+Style/RedundantParentheses:
   Exclude:
     - 'cd.rb'


### PR DESCRIPTION
Pharo is currently failing with the following stack trace:

The following stack trace is reported:

```
Error: Can't find the requested origin
        UnixResolver(PlatformResolver)>>cantFindOriginError
        [ self cantFindOriginError ] in UnixResolver(PlatformResolver)>>directoryFromEnvVariableNamed: in Block: [ self cantFindOriginError ]
        UnixResolver(PlatformResolver)>>directoryFromEnvVariableNamed:or:
        UnixResolver(PlatformResolver)>>directoryFromEnvVariableNamed:
        UnixResolver>>home
```

See for instance: https://github.com/smarr/are-we-fast-yet/actions/runs/7492188644/job/20395161374#step:17:30

If anyone knows what this might be, PRs are welcome. (Sorry for the ping, just in case someone has a thought: @guillep, @tesonep, @clementbera, @fniephaus)

But since we still have Squeak, which seems to work, I’ll disable Pharo for the moment, which is my quickest way to get the CI green... sorry.