### PR TITLE
[Pharo] Adapt to changed Smalltalk>>#saveAs: return value

### DIFF
--- a/benchmarks/Smalltalk/build-image-part2.st
+++ b/benchmarks/Smalltalk/build-image-part2.st
@@ -12,7 +12,9 @@ loader createMethods.
 ScriptConsole println: '== Safe and Exit'.
 
 starting := Smalltalk saveAs: 'AWFY_Pharo'.
-starting ifTrue: [ ^ self ].
+(starting respondsTo: #isImageStarting)
+    ifTrue: [ starting isImageStarting ifTrue: [ ^ self ] ]
+    ifFalse: [ starting ifTrue: [ ^ self ] ].
 
 runner hasPassed
   ifTrue:  [ Smalltalk exit: 0 ]


### PR DESCRIPTION
Pharo now seems to return a `SnapshotOperation` from `#saveAs:`.