### PR TITLE
Fix off-by-one in Havlak result verification.

### DIFF
--- a/benchmarks/Lua/havlak.lua
+++ b/benchmarks/Lua/havlak.lua
@@ -637,7 +637,7 @@ function havlak:verify_result (result, inner_iterations)
         return result[1] ==  1605 and result[2] == 5213
     else
         print(('No verification result for %d found'):format(inner_iterations))
-        print(('Result is: %d, %d'):format(result[0], result[1]))
+        print(('Result is: %d, %d'):format(result[1], result[2]))
         return false
     end
 end


### PR DESCRIPTION
Before, if you used a parameter with no "canned result", you would get:
```
$ lua53 harness.lua Havlak 1 2
Starting Havlak benchmark ...
No verification result for 2 found
lua53: ./havlak.lua:640: bad argument #1 to 'format' (number expected, got nil)
```