### PR TITLE
Use `ifNil:` in `isShorter:than:`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
           - { name: SOM, id: som, folder: SOM }
           - { name: Crystal, id: crystal, folder: Crystal }
           - { name: JavaScript, id: js, folder: JavaScript }
-          - { name: SOMns, id: somns, folder: SOMns, ubuntu: ubuntu-20.04 }
+          - { name: SOMns, id: somns, folder: SOMns, ubuntu: ubuntu-24.04 }
           - { name: Pharo, id: pharo, folder: Smalltalk }
           - { name: Squeak, id: squeak, folder: Smalltalk }
           - { name: Ruby, id: ruby, folder: Ruby }
@@ -119,9 +119,11 @@ jobs:
       - name: Install SOMns
         run: |
           source benchmarks/script.inc
-          load_git_repo https://github.com/smarr/SOMns.git SOMns
+          load_git_repo https://github.com/smarr/SOMns.git SOMns dev
           pushd SOMns
           git submodule update --recursive --init
+          export JAVA_HOME=$JAVA_HOME_17_X64
+          echo "JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
           ant compile
         if: matrix.id == 'somns'
 

--- a/benchmarks/SOM/CD/CollisionDetector.som
+++ b/benchmarks/SOM/CD/CollisionDetector.som
@@ -44,7 +44,7 @@ CollisionDetector = (
       newPosition := aircraft position.
       seen at: aircraft callsign put: true.
 
-      oldPosition isNil ifTrue: [
+      oldPosition ifNil: [
         "Treat newly introduced aircraft as if they were stationary"
         oldPosition := newPosition ].
 
@@ -67,7 +67,7 @@ CollisionDetector = (
           | motion2 collision |
           motion2 := reduced at: j.
           collision := motion1 findIntersection: motion2.
-          collision notNil ifTrue: [
+          collision ifNotNil: [
             collisions append: (Collision a: motion1 callsign b: motion2 callsign pos: collision) ] ] ] ].
 
     ^ collisions
@@ -132,7 +132,7 @@ CollisionDetector = (
   put: motion and: voxel into: voxelMap = (
     | array |
     array := voxelMap at: voxel.
-    array isNil ifTrue: [
+    array ifNil: [
       array := Vector new.
       voxelMap at: voxel put: array ].
     array append: motion

--- a/benchmarks/SOM/CD/Node.som
+++ b/benchmarks/SOM/CD/Node.som
@@ -52,7 +52,7 @@ Node = (
   successor = (
     | x y |
     x := self.
-    x right notNil ifTrue: [
+    x right ifNotNil: [
       ^ RedBlackTree treeMinimum: x right ].
 
     y := x parent.

--- a/benchmarks/SOM/CD/RedBlackTree.som
+++ b/benchmarks/SOM/CD/RedBlackTree.som
@@ -88,7 +88,7 @@ RedBlackTree = (
   remove: key = (
     | x y z xParent |
     z := self findNode: key.
-    z isNil ifTrue: [ ^ nil ].
+    z ifNil: [ ^ nil ].
 
     "Y is the node to be unlinked from the tree."
     (z left isNil or: [ z right isNil ])
@@ -96,22 +96,21 @@ RedBlackTree = (
       ifFalse: [ y := z successor ].
 
     "Y is guaranteed to be non-null at this point."
-    y left notNil
-      ifTrue:  [ x := y left ]
-      ifFalse: [ x := y right ].
+    y left
+      ifNotNil: [ x := y left ]
+      ifNil:    [ x := y right ].
 
     "X is the child of y which might potentially replace y in the tree.
      X might be null at this point."
-    x notNil
-      ifTrue: [
+    x ifNotNil: [
         x parent: y parent.
         xParent := x parent ]
-      ifFalse: [
+      ifNil: [
         xParent := y parent ].
 
-    y parent isNil
-      ifTrue:  [ root := x ]
-      ifFalse: [
+    y parent
+      ifNil:    [ root := x ]
+      ifNotNil: [
         y == y parent left
           ifTrue:  [ y parent left: x ]
           ifFalse: [ y parent right: x ] ].
@@ -125,17 +124,17 @@ RedBlackTree = (
       y left:   z left.
       y right:  z right.
 
-      z left notNil ifTrue: [
+      z left ifNotNil: [
         z left parent: y ].
-      x right notNil ifTrue: [
+      x right ifNotNil: [
         z right parent: y ].
 
-      z parent notNil
-        ifTrue: [
+      z parent
+        ifNotNil: [
           z parent left == z
             ifTrue:  [ z parent left: y ]
             ifFalse: [ z parent right: y ] ]
-        ifFalse: [ root := y ] ]
+        ifNil: [ root := y ] ]
       ifFalse: [
         y color = #black ifTrue: [
           self remove: x andFixup: xParent ] ].
@@ -146,13 +145,13 @@ RedBlackTree = (
   at: key = (
     | node |
     node := self findNode: key.
-    node isNil ifTrue: [ ^ nil ].
+    node ifNil: [ ^ nil ].
     ^ node value
   )
 
   forEach: block = (
     | current |
-    root isNil ifTrue: [ ^ self ].
+    root ifNil: [ ^ self ].
     current := RedBlackTree treeMinimum: root.
     [ current notNil ] whileTrue: [
       block value: (RbtEntry key: current key value: current value).
@@ -194,9 +193,8 @@ RedBlackTree = (
 
     z := Node key: key value: value.
     z parent: y.
-    y isNil
-      ifTrue: [ root := z ]
-      ifFalse: [
+    y ifNil: [ root := z ]
+      ifNotNil: [
         (key compareTo: y key) < 0
           ifTrue:  [ y left: z ]
           ifFalse: [ y right: z ] ].
@@ -210,14 +208,14 @@ RedBlackTree = (
 
     "Turn y's left subtree into x's right subtree"
     x right: y left.
-    y left notNil ifTrue: [
+    y left ifNotNil: [
       y left parent: x ].
 
     "Link x's parent to y"
     y parent: x parent.
-    x parent isNil
-      ifTrue: [ root := y ]
-      ifFalse: [
+    x parent
+      ifNil: [ root := y ]
+      ifNotNil: [
         x == x parent left ifTrue:  [ x parent left: y ]
                            ifFalse: [ x parent right: y ] ].
 
@@ -233,13 +231,13 @@ RedBlackTree = (
 
     "Turn x's right subtree into y's left subtree"
     y left: x right.
-    x right notNil ifTrue: [ x right parent: y ].
+    x right ifNotNil: [ x right parent: y ].
 
     "Link y's parent to x"
     x parent: y parent.
-    y parent isNil
-      ifTrue: [ root := x ]
-      ifFalse: [
+    y parent
+      ifNil: [ root := x ]
+      ifNotNil: [
         y == y parent left
           ifTrue: [ y parent left: x ]
           ifFalse: [ y parent right: x ] ].
@@ -287,7 +285,7 @@ RedBlackTree = (
               "Case 4"
               w color: xParent color.
               xParent color: #black.
-              w right notNil ifTrue: [
+              w right ifNotNil: [
                 w right color: #black ].
 
               self leftRotate: xParent.
@@ -322,14 +320,14 @@ RedBlackTree = (
               "Case 4"
               w color: xParent color.
               xParent color: #black.
-              w left notNil ifTrue: [
+              w left ifNotNil: [
                 w left color: #black ].
 
               self rightRotate: xParent.
               x := root.
               xParent = x parent ] ] ].
 
-    x notNil ifTrue: [ x color: #black ]
+    x ifNotNil: [ x color: #black ]
   )
   
   ----

--- a/benchmarks/SOM/CD/RedBlackTree.som
+++ b/benchmarks/SOM/CD/RedBlackTree.som
@@ -42,7 +42,7 @@ RedBlackTree = (
         ifTrue: [
           | y |
           y := x parent parent right.
-          (y notNil and: [y color = #red])
+          (y notNil and: [ y color = #red ])
             ifTrue: [
               "Case 1"
               x parent color: #black.

--- a/benchmarks/SOM/CD/RedBlackTree.som
+++ b/benchmarks/SOM/CD/RedBlackTree.som
@@ -252,7 +252,7 @@ RedBlackTree = (
     x := anX.
     xParent := anXParent.
 
-    x ~= root and: [ x isNil or: [ x color = #black ]] whileTrue: [
+    (x ~= root and: [ x isNil or: [ x color = #black ]]) whileTrue: [
       x == xParent left
         ifTrue: [
           | w |

--- a/benchmarks/SOM/Core/SomDictionary.som
+++ b/benchmarks/SOM/Core/SomDictionary.som
@@ -127,8 +127,8 @@ SomDictionary = (
     loHead := nil. loTail := nil.
     hiHead := nil. hiTail := nil.
     current := head.
-    
-    [current notNil] whileTrue: [
+
+    [ current notNil ] whileTrue: [
       (current hash & oldStorage length) = 0
         ifTrue: [
           loTail

--- a/benchmarks/SOM/Core/SomDictionary.som
+++ b/benchmarks/SOM/Core/SomDictionary.som
@@ -30,7 +30,7 @@ SomDictionary = (
 
   hash: key = (
     | hash |
-    key isNil ifTrue: [ ^ 0 ].
+    key ifNil: [ ^ 0 ].
     hash := key customHash.
     ^ hash bitXor: (hash >>> 16)
   )
@@ -72,12 +72,12 @@ SomDictionary = (
     hash := self hash: aKey.
     i    := self bucketIdx: hash.
     current := buckets at: i.
-    
-    current isNil
-      ifTrue: [
+
+    current
+      ifNil: [
         buckets at: i put: (self newEntry: aKey value: aVal hash: hash).
         size_ := size_ + 1 ]
-      ifFalse: [
+      ifNotNil: [
         self insertBucketEntry: aKey value: aVal hash: hash head: current ].
 
     size_ > buckets length ifTrue: [ self resize ]
@@ -95,7 +95,7 @@ SomDictionary = (
       (current match: hash key: key) ifTrue: [
         current value: value.
         ^ self ].
-      current next isNil ifTrue: [
+      current next ifNil: [
         size_ := size_ + 1.
         current next: (self newEntry: key value: value hash: hash).
         ^ self ].
@@ -113,12 +113,12 @@ SomDictionary = (
     1 to: oldStorage length do: [:i |
       | current |
       current := oldStorage at: i.
-      current notNil ifTrue: [
+      current ifNotNil: [
         oldStorage at: i put: nil.
-        current next isNil
-          ifTrue: [
+        current next
+          ifNil: [
             buckets at: 1 + (current hash & (buckets length - 1)) put: current ]
-          ifFalse: [
+          ifNotNil: [
             self splitBucket: oldStorage bucket: i head: current ] ] ]
   )
 
@@ -131,21 +131,21 @@ SomDictionary = (
     [current notNil] whileTrue: [
       (current hash & oldStorage length) = 0
         ifTrue: [
-          loTail isNil
-            ifTrue:  [ loHead := current ]
-            ifFalse: [ loTail next: current ].
+          loTail
+            ifNil:    [ loHead := current ]
+            ifNotNil: [ loTail next: current ].
           loTail := current ]
         ifFalse: [
-          hiTail isNil
-            ifTrue:  [ hiHead := current ]
-            ifFalse: [ hiTail next: current ].
+          hiTail
+            ifNil:    [ hiHead := current ]
+            ifNotNil: [ hiTail next: current ].
           hiTail := current ].
       current := current next ].
-  
-    loTail notNil ifTrue: [
+
+    loTail ifNotNil: [
       loTail next: nil.
       buckets at: i put: loHead ].
-    hiTail notNil ifTrue: [
+    hiTail ifNotNil: [
       hiTail next: nil.
       buckets at: i + oldStorage length put: hiHead ]
   )

--- a/benchmarks/SOM/Core/Vector.som
+++ b/benchmarks/SOM/Core/Vector.som
@@ -146,7 +146,7 @@ Vector = (
     " Sort elements i through j of self to be non-descending according to
        sortBlock. "
     | di dij dj tt ij k l n |
-    sortBlock isNil ifTrue: [ ^ self defaultSort: i to: j ].
+    sortBlock ifNil: [ ^ self defaultSort: i to: j ].
 
     "The prefix d means the data at that index."
     (n := j + 1  - i) <= 1 ifTrue: [ ^ self ]. "Nothing to sort."

--- a/benchmarks/SOM/Havlak/ControlFlowGraph.som
+++ b/benchmarks/SOM/Havlak/ControlFlowGraph.som
@@ -25,14 +25,14 @@ ControlFlowGraph = (
   createNode: name = (
     | node |
 
-    (basicBlockMap at: name) notNil
-      ifTrue:  [ node := basicBlockMap at: name ]
-      ifFalse: [
+    (basicBlockMap at: name)
+      ifNotNil: [ node := basicBlockMap at: name ]
+      ifNil: [
         node := BasicBlock new: name.
         basicBlockMap at: name put: node ].
-      
+
     self numNodes = 1 ifTrue: [startNode := node].
-    ^ node  
+    ^ node
   )
   
   addEdge: edge = (

--- a/benchmarks/SOM/Havlak/HavlakLoopFinder.som
+++ b/benchmarks/SOM/Havlak/HavlakLoopFinder.som
@@ -70,9 +70,9 @@ HavlakLoopFinder = (
       type   at: w put: #BBNonHeader.
       
       nodeW := (nodes at: w) bb.
-      nodeW isNil
-        ifTrue:  [ type at: w put: #BBDead ]
-        ifFalse: [ self processEdges: nodeW w: w ] ]
+      nodeW
+        ifNil:    [ type at: w put: #BBDead ]
+        ifNotNil: [ self processEdges: nodeW w: w ] ]
   )
   
   processEdges: nodeW w: w = (
@@ -88,8 +88,8 @@ HavlakLoopFinder = (
   
   findLoops = (
     | size |
-    cfg startBasicBlock isNil ifTrue: [ ^ self ].
-    
+    cfg startBasicBlock ifNil: [ ^ self ].
+
     size := cfg numNodes.
     
     nonBackPreds removeAll.
@@ -116,8 +116,8 @@ HavlakLoopFinder = (
       | nodePool nodeW |
       nodePool := Vector new.
       nodeW := (nodes at: w) bb.
-      
-      nodeW notNil ifTrue: [
+
+      nodeW ifNotNil: [
         | workList |
         self stepD: w nodePool: nodePool.
         
@@ -165,10 +165,10 @@ HavlakLoopFinder = (
     nodePool forEach: [:node |
       header at: node dfsNumber put: w.
       node union: (nodes at: w).
-      
-      node loop notNil
-        ifTrue: [ node loop parent: loop ]
-        ifFalse: [ loop addNode: node bb ] ]
+
+      node loop
+        ifNotNil: [ node loop parent: loop ]
+        ifNil: [ loop addNode: node bb ] ]
   )
   
   stepD: w nodePool: nodePool = (

--- a/benchmarks/SOM/Havlak/LoopStructureGraph.som
+++ b/benchmarks/SOM/Havlak/LoopStructureGraph.som
@@ -40,7 +40,7 @@ LoopStructureGraph = (
   calculateNestingLevel = (
     loops forEach: [:liter |
       liter isRoot ifFalse: [
-        liter parent isNil ifTrue: [
+        liter parent ifNil: [
           liter parent: root ] ] ].
 
     self calculateNestingLevelRec: root depth: 0

--- a/benchmarks/SOM/Havlak/SimpleLoop.som
+++ b/benchmarks/SOM/Havlak/SimpleLoop.som
@@ -30,7 +30,7 @@ SimpleLoop = (
     basicBlocks := SomIdentitySet new.
     children    := SomIdentitySet new.
 
-    aBB notNil ifTrue: [ basicBlocks add: aBB ]
+    aBB ifNotNil: [ basicBlocks add: aBB ]
   )
 
   counter = ( ^ counter )

--- a/benchmarks/SOM/List.som
+++ b/benchmarks/SOM/List.som
@@ -49,7 +49,7 @@ List = Benchmark (
     xTail := x. yTail := y.
     [ yTail isNil ]
       whileFalse: [
-        xTail isNil ifTrue: [ ^ true ].
+        xTail ifNil: [ ^ true ].
         xTail := xTail next.
         yTail := yTail next ].
 

--- a/benchmarks/SOM/ListElement.som
+++ b/benchmarks/SOM/ListElement.som
@@ -21,9 +21,9 @@ THE SOFTWARE.
 "
 ListElement = (
   | val next |
-  
-  length = ( next isNil ifTrue: [ ^ 1 ] ifFalse: [ ^ (1 + next length) ] )
-  
+
+  length = ( next ifNil: [ ^ 1 ] ifNotNil: [ ^ (1 + next length) ] )
+
   val    = ( ^ val )
   val: n = ( val := n )
   

--- a/benchmarks/SOM/Towers.som
+++ b/benchmarks/SOM/Towers.som
@@ -45,8 +45,7 @@ Towers = Benchmark (
     | top |
     
     top := piles at: pile.
-    top isNil
-      ifTrue: [
+    top ifNil: [
         self error: 'Attempting to remove a disk from an empty pile' ].
     
     piles at: pile put: top next.

--- a/benchmarks/SOMns/CD.ns
+++ b/benchmarks/SOMns/CD.ns
@@ -245,7 +245,7 @@ class CDSuite usingPlatform: platform andHarness: harness = (
     public remove: key = (
       | x y z xParent |
       z:: findNode: key.
-      z isNil ifTrue: [ ^ nil ].
+      z ifNil: [ ^ nil ].
 
       (* Y is the node to be unlinked from the tree. *)
       (z left isNil or: [ z right isNil ])
@@ -266,9 +266,9 @@ class CDSuite usingPlatform: platform andHarness: harness = (
         ifFalse: [
           xParent:: y parent ].
 
-      y parent isNil
-        ifTrue:  [ root:: x ]
-        ifFalse: [
+      y parent
+        ifNil:  [ root:: x ]
+        ifNotNil: [
           y == y parent left
             ifTrue:  [ y parent left: x ]
             ifFalse: [ y parent right: x ] ].
@@ -303,13 +303,13 @@ class CDSuite usingPlatform: platform andHarness: harness = (
     public at: key = (
       | node |
       node:: findNode: key.
-      node isNil ifTrue: [ ^ nil ].
+      node ifNil: [ ^ nil ].
       ^ node value
     )
 
     public forEach: block = (
       | current |
-      root isNil ifTrue: [ ^ self ].
+      root ifNil: [ ^ self ].
       current:: treeMinimum: root.
       [ current notNil ] whileTrue: [
         block value: (Entry key: current key value: current value).
@@ -351,9 +351,8 @@ class CDSuite usingPlatform: platform andHarness: harness = (
 
       z:: Node key: key value: value.
       z parent: y.
-      y isNil
-        ifTrue: [ root:: z ]
-        ifFalse: [
+      y ifNil: [ root:: z ]
+        ifNotNil: [
           (key compareTo: y key) < 0
             ifTrue:  [ y left: z ]
             ifFalse: [ y right: z ] ].
@@ -372,9 +371,9 @@ class CDSuite usingPlatform: platform andHarness: harness = (
 
       (* Link x's parent to y *)
       y parent: x parent.
-      x parent isNil
-        ifTrue: [ root:: y ]
-        ifFalse: [
+      x parent
+        ifNil: [ root:: y ]
+        ifNotNil: [
           x == x parent left ifTrue:  [ x parent left: y ]
                              ifFalse: [ x parent right: y ] ].
 
@@ -394,9 +393,9 @@ class CDSuite usingPlatform: platform andHarness: harness = (
 
       (* Link y's parent to x *)
       x parent: y parent.
-      y parent isNil
-        ifTrue: [ root:: x ]
-        ifFalse: [
+      y parent
+        ifNil:    [ root:: x ]
+        ifNotNil: [
           y == y parent left
             ifTrue: [ y parent left: x ]
             ifFalse: [ y parent right: x ] ].
@@ -521,7 +520,7 @@ class CDSuite usingPlatform: platform andHarness: harness = (
         newPosition:: aircraft position.
         seen at: aircraft callsign put: true.
 
-        oldPosition isNil ifTrue: [
+        oldPosition ifNil: [
           (* Treat newly introduced aircraft as if they were stationary *)
           oldPosition:: newPosition ].
 
@@ -609,7 +608,7 @@ class CDSuite usingPlatform: platform andHarness: harness = (
     private put: motion and: voxel into: voxelMap = (
       | array |
       array:: voxelMap at: voxel.
-      array isNil ifTrue: [
+      array ifNil: [
         array:: Vector new.
         voxelMap at: voxel put: array ].
       array append: motion

--- a/benchmarks/SOMns/CD.ns
+++ b/benchmarks/SOMns/CD.ns
@@ -410,7 +410,7 @@ class CDSuite usingPlatform: platform andHarness: harness = (
       x:: anX.
       xParent:: anXParent.
 
-      x ~= root and: [ x isNil or: [ x color = #black ]] whileTrue: [
+      (x ~= root and: [ x isNil or: [ x color = #black ]]) whileTrue: [
         x == xParent left
           ifTrue: [
             | w |

--- a/benchmarks/SOMns/CD.ns
+++ b/benchmarks/SOMns/CD.ns
@@ -199,7 +199,7 @@ class CDSuite usingPlatform: platform andHarness: harness = (
           ifTrue: [
             | y |
             y:: x parent parent right.
-            (y notNil and: [y color = #red])
+            (y notNil and: [ y color = #red ])
               ifTrue: [
                 (* Case 1 *)
                 x parent color: #black.

--- a/benchmarks/SOMns/Core.ns
+++ b/benchmarks/SOMns/Core.ns
@@ -150,7 +150,7 @@ class Core with: kernel = (
       (* Sort elements i through j of self to be non-descending according to
          sortBlock. *)
       | di dij dj tt ij k l n |
-      sortBlock isNil ifTrue: [ ^ self defaultSort: i to: j ].
+      sortBlock ifNil: [ ^ self defaultSort: i to: j ].
 
       (* The prefix d means the data at that index. *)
       (n:: j + 1  - i) <= 1 ifTrue: [ ^ self ]. (* Nothing to sort. *)
@@ -265,7 +265,7 @@ class Core with: kernel = (
 
     private hash: key = (
       | hash |
-      key isNil ifTrue: [ ^ 0 ].
+      key ifNil: [ ^ 0 ].
       hash:: key customHash.
       ^ hash bitXor: (hash >>> 16)
     )
@@ -308,11 +308,11 @@ class Core with: kernel = (
       i:: bucketIdx: hash.
       current:: buckets at: i.
 
-      current isNil
-        ifTrue: [
+      current
+        ifNil: [
           buckets at: i put: (newEntry: aKey value: aVal hash: hash).
           size_:: size_ + 1 ]
-        ifFalse: [
+        ifNotNil: [
           insertBucketEntry: aKey value: aVal hash: hash head: current ].
 
       size_ > buckets size ifTrue: [ resize ]
@@ -330,7 +330,7 @@ class Core with: kernel = (
         (current match: hash key: key) ifTrue: [
           current value: value.
           ^ self ].
-        current next isNil ifTrue: [
+        current next ifNil: [
           size_:: size_ + 1.
           current next: (newEntry: key value: value hash: hash).
           ^ self ].
@@ -348,12 +348,12 @@ class Core with: kernel = (
       1 to: oldStorage size do: [:i |
         | current |
         current:: oldStorage at: i.
-        current notNil ifTrue: [
+        current ifNotNil: [
           oldStorage at: i put: nil.
-          current next isNil
-            ifTrue: [
+          current next
+            ifNil: [
               buckets at: 1 + (current hash & (buckets size - 1)) put: current ]
-            ifFalse: [
+            ifNotNil: [
               splitBucket: oldStorage bucket: i head: current ] ] ]
     )
 
@@ -363,24 +363,24 @@ class Core with: kernel = (
       hiHead:: nil. hiTail:: nil.
       current:: head.
 
-      [current notNil] whileTrue: [
+      [ current notNil ] whileTrue: [
         (current hash & oldStorage size) = 0
           ifTrue: [
-            loTail isNil
-              ifTrue:  [ loHead:: current ]
-              ifFalse: [ loTail next: current ].
+            loTail
+              ifNil:    [ loHead:: current ]
+              ifNotNil: [ loTail next: current ].
             loTail:: current ]
           ifFalse: [
-            hiTail isNil
-              ifTrue:  [ hiHead:: current ]
-              ifFalse: [ hiTail next: current ].
+            hiTail
+              ifNil:    [ hiHead:: current ]
+              ifNotNil: [ hiTail next: current ].
             hiTail:: current ].
         current:: current next ].
 
-      loTail notNil ifTrue: [
+      loTail ifNotNil: [
         loTail next: nil.
         buckets at: i put: loHead ].
-      hiTail notNil ifTrue: [
+      hiTail ifNotNil: [
         hiTail next: nil.
         buckets at: i + oldStorage size put: hiHead ]
     )

--- a/benchmarks/SOMns/Havlak.ns
+++ b/benchmarks/SOMns/Havlak.ns
@@ -81,9 +81,9 @@ class Havlak usingPlatform: platform andHarness: harness = (
     public createNode: name = (
       | node |
 
-      (basicBlockMap at: name) notNil
-        ifTrue:  [ node:: basicBlockMap at: name ]
-        ifFalse: [
+      (basicBlockMap at: name)
+        ifNotNil: [ node:: basicBlockMap at: name ]
+        ifNil: [
           node:: BasicBlock new: name.
           basicBlockMap at: name put: node ].
 
@@ -130,7 +130,7 @@ class Havlak usingPlatform: platform andHarness: harness = (
     public calculateNestingLevel = (
       loops forEach: [:liter |
         liter isRoot ifFalse: [
-          liter parent isNil ifTrue: [
+          liter parent ifNil: [
             liter parent: root ] ] ].
 
       calculateNestingLevelRec: root depth: 0
@@ -160,7 +160,7 @@ class Havlak usingPlatform: platform andHarness: harness = (
     private basicBlocks = IdentitySet new.
     public  children    = IdentitySet new.
   |
-    bb notNil ifTrue: [ basicBlocks add: bb ]
+    bb ifNotNil: [ basicBlocks add: bb ]
   )(
     public addNode: bb = (
       basicBlocks add: bb
@@ -372,9 +372,9 @@ class Havlak usingPlatform: platform andHarness: harness = (
         type   at: w put: #BBNonHeader.
 
         nodeW:: (nodes at: w) bb.
-        nodeW isNil
-          ifTrue:  [ type at: w put: #BBDead ]
-          ifFalse: [ processEdges: nodeW w: w ] ]
+        nodeW
+          ifNil:    [ type at: w put: #BBDead ]
+          ifNotNil: [ processEdges: nodeW w: w ] ]
     )
 
     private processEdges: nodeW w: w = (
@@ -390,7 +390,7 @@ class Havlak usingPlatform: platform andHarness: harness = (
 
     public findLoops = (
       | size |
-      cfg startBasicBlock isNil ifTrue: [ ^ self ].
+      cfg startBasicBlock ifNil: [ ^ self ].
 
       size:: cfg numNodes.
 
@@ -419,7 +419,7 @@ class Havlak usingPlatform: platform andHarness: harness = (
         nodePool:: Vector new.
         nodeW:: (nodes at: w) bb.
 
-        nodeW notNil ifTrue: [
+        nodeW ifNotNil: [
           | workList |
           stepD: w nodePool: nodePool.
 
@@ -468,9 +468,9 @@ class Havlak usingPlatform: platform andHarness: harness = (
         header at: node dfsNumber put: w.
         node union: (nodes at: w).
 
-        node loop notNil
-          ifTrue: [ node loop parent: loop ]
-          ifFalse: [ loop addNode: node bb ] ]
+        node loop
+          ifNotNil: [ node loop parent: loop ]
+          ifNil: [ loop addNode: node bb ] ]
     )
 
     private stepD: w nodePool: nodePool = (

--- a/benchmarks/SOMns/List.ns
+++ b/benchmarks/SOMns/List.ns
@@ -51,7 +51,7 @@ class ListSuite usingPlatform: platform andHarness: harness = (
       xTail:: x. yTail:: y.
       [ yTail isNil ]
         whileFalse: [
-          xTail isNil ifTrue: [ ^ true ].
+          xTail ifNil: [ ^ true ].
           xTail:: xTail next.
           yTail:: yTail next ].
 

--- a/benchmarks/SOMns/List.ns
+++ b/benchmarks/SOMns/List.ns
@@ -74,7 +74,7 @@ class ListSuite usingPlatform: platform andHarness: harness = (
       public next ::= nil.
     |
   ) (
-    public length = ( next isNil ifTrue: [ ^ 1 ] ifFalse: [ ^ (1 + next length) ] )
+    public length = ( next ifNil: [ ^ 1 ] ifNotNil: [ ^ (1 + next length) ] )
   )
 
   public newInstance = ( ^ List new )

--- a/benchmarks/SOMns/Towers.ns
+++ b/benchmarks/SOMns/Towers.ns
@@ -44,8 +44,7 @@ class TowersSuite usingPlatform: platform andHarness: harness = (
       | top |
 
       top:: piles at: pile.
-      top isNil
-        ifTrue: [
+      top ifNil: [
           self error: 'Attempting to remove a disk from an empty pile' ].
 
       piles at: pile put: top next.

--- a/benchmarks/Smalltalk/CD/CollisionDetector.som
+++ b/benchmarks/Smalltalk/CD/CollisionDetector.som
@@ -44,7 +44,7 @@ CollisionDetector = (
       newPosition := aircraft position.
       seen at: aircraft callsign put: true.
 
-      oldPosition isNil ifTrue: [
+      oldPosition ifNil: [
         "Treat newly introduced aircraft as if they were stationary"
         oldPosition := newPosition ].
 
@@ -67,7 +67,7 @@ CollisionDetector = (
           | motion2 collision |
           motion2 := reduced at: j.
           collision := motion1 findIntersection: motion2.
-          collision notNil ifTrue: [
+          collision ifNotNil: [
             collisions append: (Collision a: motion1 callsign b: motion2 callsign pos: collision) ] ] ] ].
 
     ^ collisions
@@ -142,7 +142,7 @@ CollisionDetector = (
   put: motion and: voxel into: voxelMap = (
     | array |
     array := voxelMap at: voxel.
-    array isNil ifTrue: [
+    array ifNil: [
       array := Vector new.
       voxelMap at: voxel put: array ].
     array append: motion

--- a/benchmarks/Smalltalk/CD/Node.som
+++ b/benchmarks/Smalltalk/CD/Node.som
@@ -52,7 +52,7 @@ Node = (
   successor = (
     | x y |
     x := self.
-    x right notNil ifTrue: [
+    x right ifNotNil: [
       ^ RedBlackTree treeMinimum: x right ].
 
     y := x parent.

--- a/benchmarks/Smalltalk/CD/RedBlackTree.som
+++ b/benchmarks/Smalltalk/CD/RedBlackTree.som
@@ -88,7 +88,7 @@ RedBlackTree = (
   remove: key = (
     | x y z xParent |
     z := self findNode: key.
-    z isNil ifTrue: [ ^ nil ].
+    z ifNil: [ ^ nil ].
 
     "Y is the node to be unlinked from the tree."
     (z left isNil or: [ z right isNil ])
@@ -96,22 +96,21 @@ RedBlackTree = (
       ifFalse: [ y := z successor ].
 
     "Y is guaranteed to be non-null at this point."
-    y left notNil
-      ifTrue:  [ x := y left ]
-      ifFalse: [ x := y right ].
+    y left
+      ifNotNil: [ x := y left ]
+      ifNil:    [ x := y right ].
 
     "X is the child of y which might potentially replace y in the tree.
      X might be null at this point."
-    x notNil
-      ifTrue: [
+    x ifNotNil: [
         x parent: y parent.
         xParent := x parent ]
-      ifFalse: [
+      ifNil: [
         xParent := y parent ].
 
-    y parent isNil
-      ifTrue:  [ root := x ]
-      ifFalse: [
+    y parent
+      ifNil: [ root := x ]
+      ifNotNil: [
         y == y parent left
           ifTrue:  [ y parent left: x ]
           ifFalse: [ y parent right: x ] ].
@@ -125,17 +124,17 @@ RedBlackTree = (
       y left:   z left.
       y right:  z right.
 
-      z left notNil ifTrue: [
+      z left ifNotNil: [
         z left parent: y ].
-      x right notNil ifTrue: [
+      x right ifNotNil: [
         z right parent: y ].
 
-      z parent notNil
-        ifTrue: [
+      z parent
+        ifNotNil: [
           z parent left == z
             ifTrue:  [ z parent left: y ]
             ifFalse: [ z parent right: y ] ]
-        ifFalse: [ root := y ] ]
+        ifNil: [ root := y ] ]
       ifFalse: [
         y color = #black ifTrue: [
           self remove: x andFixup: xParent ] ].
@@ -146,13 +145,13 @@ RedBlackTree = (
   at: key = (
     | node |
     node := self findNode: key.
-    node isNil ifTrue: [ ^ nil ].
+    node ifNil: [ ^ nil ].
     ^ node value
   )
 
   forEach: block = (
     | current |
-    root isNil ifTrue: [ ^ self ].
+    root ifNil: [ ^ self ].
     current := RedBlackTree treeMinimum: root.
     [ current notNil ] whileTrue: [
       block value: (RbtEntry key: current key value: current value).
@@ -194,13 +193,12 @@ RedBlackTree = (
 
     z := Node key: key value: value.
     z parent: y.
-    y isNil
-      ifTrue: [ root := z ]
-      ifFalse: [
+    y ifNil: [ root := z ]
+      ifNotNil: [
         (key compareTo: y key) < 0
           ifTrue:  [ y left: z ]
           ifFalse: [ y right: z ] ].
-    
+
     ^ InsertResult new: true node: z value: nil
   )
 
@@ -210,14 +208,14 @@ RedBlackTree = (
 
     "Turn y's left subtree into x's right subtree"
     x right: y left.
-    y left notNil ifTrue: [
+    y left ifNotNil: [
       y left parent: x ].
 
     "Link x's parent to y"
     y parent: x parent.
-    x parent isNil
-      ifTrue: [ root := y ]
-      ifFalse: [
+    x parent
+      ifNil: [ root := y ]
+      ifNotNil: [
         x == x parent left ifTrue:  [ x parent left: y ]
                            ifFalse: [ x parent right: y ] ].
 
@@ -233,13 +231,13 @@ RedBlackTree = (
 
     "Turn x's right subtree into y's left subtree"
     y left: x right.
-    x right notNil ifTrue: [ x right parent: y ].
+    x right ifNotNil: [ x right parent: y ].
 
     "Link y's parent to x"
     x parent: y parent.
-    y parent isNil
-      ifTrue: [ root := x ]
-      ifFalse: [
+    y parent
+      ifNil: [ root := x ]
+      ifNotNil: [
         y == y parent left
           ifTrue: [ y parent left: x ]
           ifFalse: [ y parent right: x ] ].
@@ -287,7 +285,7 @@ RedBlackTree = (
               "Case 4"
               w color: xParent color.
               xParent color: #black.
-              w right notNil ifTrue: [
+              w right ifNotNil: [
                 w right color: #black ].
 
               self leftRotate: xParent.
@@ -322,14 +320,14 @@ RedBlackTree = (
               "Case 4"
               w color: xParent color.
               xParent color: #black.
-              w left notNil ifTrue: [
+              w left ifNotNil: [
                 w left color: #black ].
 
               self rightRotate: xParent.
               x := root.
               xParent = x parent ] ] ].
 
-    x notNil ifTrue: [ x color: #black ]
+    x ifNotNil: [ x color: #black ]
   )
   
   ----

--- a/benchmarks/Smalltalk/CD/RedBlackTree.som
+++ b/benchmarks/Smalltalk/CD/RedBlackTree.som
@@ -42,7 +42,7 @@ RedBlackTree = (
         ifTrue: [
           | y |
           y := x parent parent right.
-          (y notNil and: [y color = #red])
+          (y notNil and: [ y color = #red ])
             ifTrue: [
               "Case 1"
               x parent color: #black.

--- a/benchmarks/Smalltalk/CD/RedBlackTree.som
+++ b/benchmarks/Smalltalk/CD/RedBlackTree.som
@@ -252,7 +252,7 @@ RedBlackTree = (
     x := anX.
     xParent := anXParent.
 
-    x ~= root and: [ x isNil or: [ x color = #black ]] whileTrue: [
+    (x ~= root and: [ x isNil or: [ x color = #black ]]) whileTrue: [
       x == xParent left
         ifTrue: [
           | w |

--- a/benchmarks/Smalltalk/Core/SomDictionary.som
+++ b/benchmarks/Smalltalk/Core/SomDictionary.som
@@ -30,7 +30,7 @@ SomDictionary = (
 
   hash: key = (
     | hash |
-    key isNil ifTrue: [ ^ 0 ].
+    key ifNil: [ ^ 0 ].
     hash := key customHash.
     ^ hash bitXor: (hash >> 16)
   )
@@ -72,12 +72,12 @@ SomDictionary = (
     hash := self hash: aKey.
     i    := self bucketIdx: hash.
     current := buckets at: i.
-    
-    current isNil
-      ifTrue: [
+
+    current
+      ifNil: [
         buckets at: i put: (self newEntry: aKey value: aVal hash: hash).
         size_ := size_ + 1 ]
-      ifFalse: [
+      ifNotNil: [
         self insertBucketEntry: aKey value: aVal hash: hash head: current ].
 
     size_ > buckets size ifTrue: [ self resize ]
@@ -95,7 +95,7 @@ SomDictionary = (
       (current match: hash key: key) ifTrue: [
         current value: value.
         ^ self ].
-      current next isNil ifTrue: [
+      current next ifNil: [
         size_ := size_ + 1.
         current next: (self newEntry: key value: value hash: hash).
         ^ self ].
@@ -113,12 +113,12 @@ SomDictionary = (
     1 to: oldStorage size do: [:i |
       | current |
       current := oldStorage at: i.
-      current notNil ifTrue: [
+      current ifNotNil: [
         oldStorage at: i put: nil.
-        current next isNil
-          ifTrue: [
+        current next
+          ifNil: [
             buckets at: 1 + (current hash & (buckets size - 1)) put: current ]
-          ifFalse: [
+          ifNotNil: [
             self splitBucket: oldStorage bucket: i head: current ] ] ]
   )
 
@@ -131,21 +131,21 @@ SomDictionary = (
     [current notNil] whileTrue: [
       (current hash & oldStorage size) = 0
         ifTrue: [
-          loTail isNil
-            ifTrue:  [ loHead := current ]
-            ifFalse: [ loTail next: current ].
+          loTail
+            ifNil:  [ loHead := current ]
+            ifNotNil: [ loTail next: current ].
           loTail := current ]
         ifFalse: [
-          hiTail isNil
-            ifTrue:  [ hiHead := current ]
-            ifFalse: [ hiTail next: current ].
+          hiTail
+            ifNil:  [ hiHead := current ]
+            ifNotNil: [ hiTail next: current ].
           hiTail := current ].
       current := current next ].
-  
-    loTail notNil ifTrue: [
+
+    loTail ifNotNil: [
       loTail next: nil.
       buckets at: i put: loHead ].
-    hiTail notNil ifTrue: [
+    hiTail ifNotNil: [
       hiTail next: nil.
       buckets at: i + oldStorage size put: hiHead ]
   )

--- a/benchmarks/Smalltalk/Core/Vector.som
+++ b/benchmarks/Smalltalk/Core/Vector.som
@@ -146,7 +146,7 @@ Vector = (
     " Sort elements i through j of self to be non-descending according to
        sortBlock. "
     | di dij dj tt ij k l n |
-    sortBlock isNil ifTrue: [ ^ self defaultSort: i to: j ].
+    sortBlock ifNil: [ ^ self defaultSort: i to: j ].
 
     "The prefix d means the data at that index."
     (n := j + 1  - i) <= 1 ifTrue: [ ^ self ]. "Nothing to sort."

--- a/benchmarks/Smalltalk/Havlak/ControlFlowGraph.som
+++ b/benchmarks/Smalltalk/Havlak/ControlFlowGraph.som
@@ -25,14 +25,14 @@ ControlFlowGraph = (
   createNode: name = (
     | node |
 
-    (basicBlockMap at: name) notNil
-      ifTrue:  [ node := basicBlockMap at: name ]
-      ifFalse: [
+    (basicBlockMap at: name)
+      ifNotNil: [ node := basicBlockMap at: name ]
+      ifNil: [
         node := BasicBlock new: name.
         basicBlockMap at: name put: node ].
       
     self numNodes = 1 ifTrue: [startNode := node].
-    ^ node  
+    ^ node
   )
   
   addEdge: edge = (

--- a/benchmarks/Smalltalk/Havlak/HavlakLoopFinder.som
+++ b/benchmarks/Smalltalk/Havlak/HavlakLoopFinder.som
@@ -70,9 +70,9 @@ HavlakLoopFinder = (
       type   at: w put: #BBNonHeader.
       
       nodeW := (nodes at: w) bb.
-      nodeW isNil
-        ifTrue:  [ type at: w put: #BBDead ]
-        ifFalse: [ self processEdges: nodeW w: w ] ]
+      nodeW
+        ifNil:    [ type at: w put: #BBDead ]
+        ifNotNil: [ self processEdges: nodeW w: w ] ]
   )
   
   processEdges: nodeW w: w = (
@@ -88,8 +88,8 @@ HavlakLoopFinder = (
   
   findLoops = (
     | size |
-    cfg startBasicBlock isNil ifTrue: [ ^ self ].
-    
+    cfg startBasicBlock ifNil: [ ^ self ].
+
     size := cfg numNodes.
     
     nonBackPreds removeAll.
@@ -116,8 +116,8 @@ HavlakLoopFinder = (
       | nodePool nodeW |
       nodePool := Vector new.
       nodeW := (nodes at: w) bb.
-      
-      nodeW notNil ifTrue: [
+
+      nodeW ifNotNil: [
         | workList |
         self stepD: w nodePool: nodePool.
         
@@ -165,10 +165,10 @@ HavlakLoopFinder = (
     nodePool forEach: [:node |
       header at: node dfsNumber put: w.
       node union: (nodes at: w).
-      
-      node loop notNil
-        ifTrue: [ node loop parent: loop ]
-        ifFalse: [ loop addNode: node bb ] ]
+
+      node loop
+        ifNotNil: [ node loop parent: loop ]
+        ifNil:    [ loop addNode: node bb ] ]
   )
   
   stepD: w nodePool: nodePool = (

--- a/benchmarks/Smalltalk/Havlak/LoopStructureGraph.som
+++ b/benchmarks/Smalltalk/Havlak/LoopStructureGraph.som
@@ -40,7 +40,7 @@ LoopStructureGraph = (
   calculateNestingLevel = (
     loops forEach: [:liter |
       liter isRoot ifFalse: [
-        liter parent isNil ifTrue: [
+        liter parent ifNil: [
           liter parent: root ] ] ].
 
     self calculateNestingLevelRec: root depth: 0

--- a/benchmarks/Smalltalk/Havlak/SimpleLoop.som
+++ b/benchmarks/Smalltalk/Havlak/SimpleLoop.som
@@ -30,7 +30,7 @@ SimpleLoop = (
     basicBlocks := SomIdentitySet new.
     children    := SomIdentitySet new.
 
-    aBB notNil ifTrue: [ basicBlocks add: aBB ]
+    aBB ifNotNil: [ basicBlocks add: aBB ]
   )
 
   counter = ( ^ counter )

--- a/benchmarks/Smalltalk/List.som
+++ b/benchmarks/Smalltalk/List.som
@@ -49,7 +49,7 @@ List = Benchmark (
     xTail := x. yTail := y.
     [ yTail isNil ]
       whileFalse: [
-        xTail isNil ifTrue: [ ^ true ].
+        xTail ifNil: [ ^ true ].
         xTail := xTail next.
         yTail := yTail next ].
 

--- a/benchmarks/Smalltalk/ListElement.som
+++ b/benchmarks/Smalltalk/ListElement.som
@@ -21,9 +21,9 @@ THE SOFTWARE.
 "
 ListElement = (
   | val next |
-  
-  length = ( next isNil ifTrue: [ ^ 1 ] ifFalse: [ ^ (1 + next length) ] )
-  
+
+  length = ( next ifNil: [ ^ 1 ] ifNotNil: [ ^ (1 + next length) ] )
+
   val    = ( ^ val )
   val: n = ( val := n )
   

--- a/benchmarks/Smalltalk/Towers.som
+++ b/benchmarks/Smalltalk/Towers.som
@@ -45,8 +45,7 @@ Towers = Benchmark (
     | top |
     
     top := piles at: pile.
-    top isNil
-      ifTrue: [
+    top ifNil: [
         self error: 'Attempting to remove a disk from an empty pile' ].
     
     piles at: pile put: top next.


### PR DESCRIPTION
I'd argue this is slightly more idiomatic and it seems that this is also [supported in SOM](https://github.com/SOM-st/SOM/blob/f11313b14e6b85c1b5c5567e5b8cedc4b8e814fd/Smalltalk/Object.som#L51). In fact, the Squeak/Smalltalk compiler turns `ifNil:` into an identity check (`== nil`) plus jump rather than sending `isNil` to the receiver and then jump.

I noticed this some time ago when I looked into excessive splitting in TruffleSqueak ([here's 
a recent example](https://gist.github.com/TruffleSqueak-Bot/0fb5cbff18d9f47b3305a4d1879aa2bc#file-9ce8a19c-list-trace-log)). It turned out that the additional `isNil` send causes these splits.

Surely, there are ways to fix the splitting issue in TruffleSqueak. I just thought I open this anyway because, again, it is more idiomatic and because of that, also specifically optimized by the Squeak/Smalltalk compiler.